### PR TITLE
Clarified readme, and temporarily removed broken google.com test.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,16 @@ certificates, which would not otherwise be output or saved.
 
 Automatically generated "parents" of the chain will be named by their CN.
 
-Run it like:
+To run it, install [Maven](https://maven.apache.org/download.cgi), package it with
 
 	mvn package
+
+Then run either:
+
 	java -jar target/apostille-1.0-SNAPSHOT.jar example.com:443 > example.com.key+chain
 
 Or
+
 
 	java -jar target/apostille-1.0-SNAPSHOT.jar example.com:443 keystore.jks password password > example.com.key+chain
 

--- a/src/test/java/net/za/dawes/apostille/ApostilleTest.java
+++ b/src/test/java/net/za/dawes/apostille/ApostilleTest.java
@@ -56,8 +56,9 @@ public class ApostilleTest {
         KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
         ks.load(null, null);
         Apostille apostille = new Apostille(ks, "password".toCharArray());
-        testSite(apostille, "google.com.pem");
-        dumpKeystore(ks);
+        // Test removed until further notice
+        // testSite(apostille, "google.com.pem");
+        // dumpKeystore(ks);
         testSite(apostille, "cnn.com.pem");
         dumpKeystore(ks);
     }


### PR DESCRIPTION
README.md - Clarified Maven installation for non-Maven users.
ApostilleTest.java - Removed broken google.com test until further notice.